### PR TITLE
Fixed sleep function to Sleep for mingw

### DIFF
--- a/src/proto/os/mingw32/tiny_defines.h
+++ b/src/proto/os/mingw32/tiny_defines.h
@@ -48,7 +48,7 @@
 
 #define COND_SIGNAL(x)    pthread_cond_signal(&x)
 
-#define TASK_YIELD()      sleep(0)
+#define TASK_YIELD()      Sleep(0)
 
 
 static inline uint16_t PLATFORM_TICKS()


### PR DESCRIPTION
This is a hot fix for sleep undefined reference issue #4 