### PR TITLE
Use names specific to tinyproto for CRC related functions.

### DIFF
--- a/src/TinyProtocolFd.h
+++ b/src/TinyProtocolFd.h
@@ -298,7 +298,7 @@ public:
     }
 
 private:
-    uint8_t m_data[S]{};
+    uint8_t m_data[S] __attribute__ ((aligned (16))) {};
 };
 
 /**

--- a/src/proto/crc/tiny_crc.c
+++ b/src/proto/crc/tiny_crc.c
@@ -17,7 +17,7 @@
     along with Protocol Library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "crc.h"
+#include "tiny_crc.h"
 
 /* CRC32 RFC1662 (PPP in HDLC-like framing) */
 
@@ -65,7 +65,7 @@ uint32_t crc32_byte(uint32_t crc, uint8_t data)
     return fcstab_32[(crc ^ data) & 0xFF] ^ (crc >> 8);
 }
 
-uint32_t crc32(uint32_t crc, const uint8_t *buf, int size)
+uint32_t tiny_crc32(uint32_t crc, const uint8_t *buf, int size)
 {
     const uint8_t *p;
 
@@ -115,7 +115,7 @@ uint16_t crc16_byte(uint16_t crc, uint8_t data)
     return (crc >> 8) ^ fcstab_16[(crc ^ (data)) & 0xff];
 }
 
-uint16_t crc16(uint16_t crc, const uint8_t *data, int data_length)
+uint16_t tiny_crc16(uint16_t crc, const uint8_t* data, int data_length)
 {
     while ( data_length )
     {
@@ -136,7 +136,7 @@ uint16_t chksum_byte(uint16_t sum, uint8_t data)
     return sum + data;
 }
 
-uint16_t chksum(uint16_t sum, const uint8_t *data, int data_length)
+uint16_t tiny_chksum(uint16_t sum, const uint8_t* data, int data_length)
 {
     while ( data_length )
     {

--- a/src/proto/crc/tiny_crc.h
+++ b/src/proto/crc/tiny_crc.h
@@ -31,21 +31,21 @@ extern "C"
 #define INITCHECKSUM 0x0000
 #define GOODCHECKSUM 0x0000
     uint16_t chksum_byte(uint16_t sum, uint8_t data);
-    uint16_t chksum(uint16_t sum, const uint8_t *data, int data_length);
+    uint16_t tiny_chksum(uint16_t sum, const uint8_t* data, int data_length);
 #endif
 
 #ifdef CONFIG_ENABLE_FCS16
 #define PPPINITFCS16 0xffff /* Initial FCS value */
 #define PPPGOODFCS16 0xf0b8 /* Good final FCS value */
     uint16_t crc16_byte(uint16_t crc, uint8_t data);
-    uint16_t crc16(uint16_t crc, const uint8_t *data, int data_length);
+    uint16_t tiny_crc16(uint16_t crc, const uint8_t* data, int data_length);
 #endif
 
 #ifdef CONFIG_ENABLE_FCS32
 #define PPPINITFCS32 0xffffffff /* Initial FCS value */
 #define PPPGOODFCS32 0xdebb20e3 /* Good final FCS value */
     uint32_t crc32_byte(uint32_t crc, uint8_t data);
-    uint32_t crc32(uint32_t crc, const uint8_t *buf, int size);
+    uint32_t tiny_crc32(uint32_t crc, const uint8_t *buf, int size);
 #endif
 
 /// \cond

--- a/src/proto/fd/tiny_fd.h
+++ b/src/proto/fd/tiny_fd.h
@@ -34,7 +34,7 @@ extern "C"
 #endif
 
 #include <stdint.h>
-#include "proto/crc/crc.h"
+#include "proto/crc/tiny_crc.h"
 #include "hal/tiny_types.h"
 
     /**

--- a/src/proto/fd/tiny_fd_int.h
+++ b/src/proto/fd/tiny_fd_int.h
@@ -33,7 +33,7 @@ extern "C"
 #include "proto/hdlc/low_level/hdlc_int.h"
 #include "hal/tiny_types.h"
 
-#define FD_MIN_BUF_SIZE(mtu, window) ( (sizeof(tiny_fd_data_t) + \
+#define FD_MIN_BUF_SIZE(mtu, window) ( sizeof(tiny_fd_data_t) + \
                                       HDLC_MIN_BUF_SIZE( mtu + sizeof(tiny_frame_header_t), HDLC_CRC_16 ) + \
                                       ( sizeof(tiny_i_frame_info_t *) + sizeof(tiny_i_frame_info_t) + mtu \
                                                                       - sizeof(((tiny_i_frame_info_t *)0)->user_payload) ) * window )

--- a/src/proto/hdlc/high_level/hdlc.c
+++ b/src/proto/hdlc/high_level/hdlc.c
@@ -18,7 +18,7 @@
 */
 
 #include "proto/hdlc/high_level/hdlc.h"
-#include "proto/crc/crc.h"
+#include "proto/crc/tiny_crc.h"
 #include "proto/hdlc/low_level/hdlc_int.h"
 #include "hal/tiny_debug.h"
 

--- a/src/proto/hdlc/high_level/hdlc.h
+++ b/src/proto/hdlc/high_level/hdlc.h
@@ -20,7 +20,7 @@
 
 #include "hal/tiny_types.h"
 #include "proto/hdlc/low_level/hdlc.h"
-#include "proto/crc/crc.h"
+#include "proto/crc/tiny_crc.h"
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/src/proto/hdlc/low_level/hdlc.c
+++ b/src/proto/hdlc/low_level/hdlc.c
@@ -19,7 +19,7 @@
 
 #include "hdlc.h"
 #include "hdlc_int.h"
-#include "proto/crc/crc.h"
+#include "proto/crc/tiny_crc.h"
 #include "hal/tiny_debug.h"
 
 #include <stddef.h>
@@ -127,13 +127,13 @@ static int hdlc_ll_send_start(hdlc_ll_handle_t handle)
     switch ( handle->crc_type )
     {
 #ifdef CONFIG_ENABLE_FCS16
-        case HDLC_CRC_16: handle->tx.crc = crc16(PPPINITFCS16, handle->tx.data, handle->tx.len); break;
+        case HDLC_CRC_16: handle->tx.crc = tiny_crc16(PPPINITFCS16, handle->tx.data, handle->tx.len); break;
 #endif
 #ifdef CONFIG_ENABLE_FCS32
-        case HDLC_CRC_32: handle->tx.crc = crc32(PPPINITFCS32, handle->tx.data, handle->tx.len); break;
+        case HDLC_CRC_32: handle->tx.crc = tiny_crc32(PPPINITFCS32, handle->tx.data, handle->tx.len); break;
 #endif
 #ifdef CONFIG_ENABLE_CHECKSUM
-        case HDLC_CRC_8: handle->tx.crc = chksum(INITCHECKSUM, handle->tx.data, handle->tx.len); break;
+        case HDLC_CRC_8: handle->tx.crc = tiny_chksum(INITCHECKSUM, handle->tx.data, handle->tx.len); break;
 #endif
         default: break;
     }
@@ -444,19 +444,19 @@ static int hdlc_ll_read_end(hdlc_ll_handle_t handle, const uint8_t *data, int le
     {
 #ifdef CONFIG_ENABLE_CHECKSUM
         case HDLC_CRC_8:
-            calc_crc = chksum(INITCHECKSUM, handle->rx_buf, len - 1) & 0x00FF;
+            calc_crc = tiny_chksum(INITCHECKSUM, handle->rx_buf, len - 1) & 0x00FF;
             read_crc = handle->rx.data[-1];
             break;
 #endif
 #ifdef CONFIG_ENABLE_FCS16
         case HDLC_CRC_16:
-            calc_crc = crc16(PPPINITFCS16, handle->rx_buf, len - 2);
+            calc_crc = tiny_crc16(PPPINITFCS16, handle->rx_buf, len - 2);
             read_crc = handle->rx.data[-2] | ((uint16_t)handle->rx.data[-1] << 8);
             break;
 #endif
 #ifdef CONFIG_ENABLE_FCS32
         case HDLC_CRC_32:
-            calc_crc = crc32(PPPINITFCS32, handle->rx_buf, len - 4);
+            calc_crc = tiny_crc32(PPPINITFCS32, handle->rx_buf, len - 4);
             read_crc = handle->rx.data[-4] | ((uint32_t)handle->rx.data[-3] << 8) |
                        ((uint32_t)handle->rx.data[-2] << 16) | ((uint32_t)handle->rx.data[-1] << 24);
             break;

--- a/src/proto/hdlc/low_level/hdlc.h
+++ b/src/proto/hdlc/low_level/hdlc.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "hal/tiny_types.h"
-#include "proto/crc/crc.h"
+#include "proto/crc/tiny_crc.h"
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/src/proto/hdlc/low_level/hdlc_int.h
+++ b/src/proto/hdlc/low_level/hdlc_int.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "hal/tiny_types.h"
-#include "proto/crc/crc.h"
+#include "proto/crc/tiny_crc.h"
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/unittest/hal_tests.cpp
+++ b/unittest/hal_tests.cpp
@@ -26,7 +26,7 @@
 #include "hal/tiny_types.h"
 #include "hal/tiny_list.h"
 #include "hal/tiny_debug.h"
-#include "proto/crc/crc.h"
+#include "proto/crc/tiny_crc.h"
 
 TEST_GROUP(HAL){void setup(){
     // ...
@@ -102,19 +102,19 @@ TEST(HAL, crc)
     uint8_t buf[256];
     for ( unsigned int i = 0; i < 256; i++ )
         buf[i] = i;
-    uint8_t crc8_num = chksum(INITCHECKSUM, buf, sizeof(buf));
-    uint16_t crc16_num = crc16(PPPINITFCS16, buf, sizeof(buf));
-    uint32_t crc32_num = crc32(PPPINITFCS32, buf, sizeof(buf));
+    uint8_t crc8_num = tiny_chksum(INITCHECKSUM, buf, sizeof(buf));
+    uint16_t crc16_num = tiny_crc16(PPPINITFCS16, buf, sizeof(buf));
+    uint32_t crc32_num = tiny_crc32(PPPINITFCS32, buf, sizeof(buf));
     CHECK_EQUAL(0x7F, crc8_num);
-    CHECK_EQUAL(GOODCHECKSUM, chksum(0xFFFF - crc8_num, &crc8_num, 1));
+    CHECK_EQUAL(GOODCHECKSUM, tiny_chksum(0xFFFF - crc8_num, &crc8_num, 1));
     CHECK_EQUAL(GOODCHECKSUM, 0xFFFF - chksum_byte(0xFFFF - crc8_num, crc8_num));
     uint16_t crc16_swap = crc16_num;
     CHECK_EQUAL(0x303C, crc16_num);
-    CHECK_EQUAL(PPPGOODFCS16, (uint16_t)(crc16(crc16_num ^ ~0U, (uint8_t *)&crc16_swap, 2) ^ ~0U));
+    CHECK_EQUAL(PPPGOODFCS16, (uint16_t)(tiny_crc16(crc16_num ^ ~0U, (uint8_t *)&crc16_swap, 2) ^ ~0U));
     CHECK_EQUAL(PPPGOODFCS16, (uint16_t)(crc16_byte(crc16_byte(crc16_num ^ ~0U, crc16_num & 0xFF), crc16_num >> 8)));
     uint32_t crc32_swap = crc32_num;
     CHECK_EQUAL(0x29058C73, crc32_num);
-    CHECK_EQUAL(PPPGOODFCS32, (uint32_t)(crc32(crc32_num ^ ~0U, (uint8_t *)&crc32_swap, 4) ^ ~0U));
+    CHECK_EQUAL(PPPGOODFCS32, (uint32_t)(tiny_crc32(crc32_num ^ ~0U, (uint8_t *)&crc32_swap, 4) ^ ~0U));
     CHECK_EQUAL(PPPGOODFCS32, (uint32_t)(crc32_byte(crc32_byte(crc32_byte(crc32_byte(crc32_num ^ ~0U, crc32_num & 0xFF),
                                                                           (crc32_num >> 8) & 0xFF),
                                                                (crc32_num >> 16) & 0xFF),


### PR DESCRIPTION
Present names are so generic, so they cause problems when linking with other projects i.e. Zephyr RTOS.

Signed-off-by: Artur Lipowski <Artur.Lipowski@hidglobal.com>