### PR TITLE
fix(tiny_fd): set FD_EVENT_QUEUE_HAS_FREE_SLOTS on re-connection

### DIFF
--- a/src/proto/fd/tiny_fd.c
+++ b/src/proto/fd/tiny_fd.c
@@ -388,7 +388,10 @@ static void __switch_to_connected_state(tiny_fd_handle_t handle, uint8_t peer)
         tiny_fd_queue_reset_for( &handle->frames.i_queue, __peer_to_address_field( handle, peer ) );
         handle->peers[peer].last_ka_ts = tiny_millis();
         tiny_events_set(&handle->peers[peer].events, FD_EVENT_CAN_ACCEPT_I_FRAMES);
-        tiny_events_set(&handle->events, FD_EVENT_TX_DATA_AVAILABLE);
+        tiny_events_set(
+            &handle->events,
+            FD_EVENT_TX_DATA_AVAILABLE |
+                (tiny_fd_queue_has_free_slots(&handle->frames.i_queue) ? FD_EVENT_QUEUE_HAS_FREE_SLOTS : 0));
         LOG(TINY_LOG_CRIT, "[%p] Connection is established\n", handle);
         if ( handle->on_connect_event_cb )
         {


### PR DESCRIPTION
If, before disconnection, the TX buffer was filled, not setting FD_EVENT_QUEUE_HAS_FREE_SLOTS on-reconnection means that no more TX frames can be enqueued.