### PR TITLE
fix(tiny_fd): assert disconnection on (re-)connection request of a co…

### DIFF
--- a/src/proto/fd/tiny_fd.c
+++ b/src/proto/fd/tiny_fd.c
@@ -519,6 +519,10 @@ static int __on_u_frame_read(tiny_fd_handle_t handle, uint8_t peer, void *data, 
             .control = HDLC_U_FRAME_TYPE_UA | HDLC_U_FRAME_BITS,
         };
         __put_u_s_frame_to_tx_queue(handle, TINY_FD_QUEUE_U_FRAME, &frame, 2);
+        if ( handle->peers[peer].state == TINY_FD_STATE_CONNECTED )
+        {
+            __switch_to_disconnected_state(handle, peer);
+        }
         __switch_to_connected_state(handle, peer);
     }
     else if ( type == HDLC_U_FRAME_TYPE_DISC )
@@ -1393,4 +1397,3 @@ int tiny_fd_register_peer(tiny_fd_handle_t handle, uint8_t address)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-


### PR DESCRIPTION
This may happen for example if the peer was reset and right after boot it sends the SABM or SNRM frame. If the startup time of the peer is short (in the worst case it is enough that the startup time is less than the keep-alive timeout), it is possible that the primary has not detected the disconnection of peer yet.
