### PR TITLE
Fixes to examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 # Added by cargo
 
 /target
+
+
+# build folder
+build/

--- a/examples/esp32_idf/spi/master/main/app_main.c
+++ b/examples/esp32_idf/spi/master/main/app_main.c
@@ -209,7 +209,7 @@ void app_main()
 
     s_hdlc.crc_type = HDLC_CRC_16;
     s_hdlc.on_frame_read = on_receive;
-    s_hdlc.on_frame_sent = on_send;
+    s_hdlc.on_frame_send = on_send;
     s_hdlc.rx_buf = s_hdlc_rx_buffer;
     s_hdlc.rx_buf_size = sizeof(s_hdlc_rx_buffer);
 

--- a/examples/esp32_idf/spi/slave/main/app_main.c
+++ b/examples/esp32_idf/spi/slave/main/app_main.c
@@ -174,7 +174,7 @@ void app_main()
 
     s_hdlc.crc_type = HDLC_CRC_16;
     s_hdlc.on_frame_read = on_receive;
-    s_hdlc.on_frame_sent = on_send;
+    s_hdlc.on_frame_send = on_send;
     s_hdlc.rx_buf = s_hdlc_rx_buffer;
     s_hdlc.rx_buf_size = sizeof(s_hdlc_rx_buffer);
 

--- a/examples/linux/hdlc_demo/hdlc_demo.cpp
+++ b/examples/linux/hdlc_demo/hdlc_demo.cpp
@@ -71,7 +71,7 @@ static int on_frame_read(void *user_data, void *data, int len)
     return 0;
 }
 
-static int on_frame_sent(void *user_data, const void *data, int len)
+static int on_frame_send(void *user_data, const void *data, int len)
 {
     // This callback is called, when frame is sent
     fprintf(stderr, "Sent message '%.*s'\n", len, (char *)data);
@@ -92,7 +92,7 @@ static void protocol_thread(tiny_serial_handle_t serial)
     hdlc_struct_t conf{};
     conf.send_tx = nullptr;
     conf.on_frame_read = on_frame_read;
-    conf.on_frame_sent = on_frame_sent;
+    conf.on_frame_send = on_frame_send;
     conf.rx_buf = malloc(1024);
     conf.rx_buf_size = 1024;
     conf.crc_type = HDLC_CRC_16;

--- a/examples/linux/hdlc_demo_multithread/hdlc_demo_multithread.cpp
+++ b/examples/linux/hdlc_demo_multithread/hdlc_demo_multithread.cpp
@@ -64,7 +64,7 @@ static int on_frame_read(void *user_data, void *data, int len)
     return 0;
 }
 
-static int on_frame_sent(void *user_data, const void *data, int len)
+static int on_frame_send(void *user_data, const void *data, int len)
 {
     // This callback is called, when frame is sent
     fprintf(stderr, "Sent message '%.*s'\n", len, (char *)data);
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
     hdlc_struct_t conf{};
     conf.send_tx = nullptr;
     conf.on_frame_read = on_frame_read;
-    conf.on_frame_sent = on_frame_sent;
+    conf.on_frame_send = on_frame_send;
     conf.rx_buf = malloc(1024);
     conf.rx_buf_size = 1024;
     conf.crc_type = HDLC_CRC_16;


### PR DESCRIPTION
Fixed examples: `conf.on_frame_sent` > `conf.on_frame_send`