### PR TITLE
Change CXX STANDARD to 11 since clang16 or earlier needs it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required (VERSION 3.5)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 option(EXAMPLES "Build examples and tiny_loopback" OFF)
 option(UNITTEST "Build unit tests" OFF)
 option(CUSTOM "Do not use built-in HAL, but use Custom instead" OFF)


### PR DESCRIPTION
Hi @lexus2k ,

Could you please merge this PR and tag again, since we encountered issues with macOS build on vcpkg PR, it is needed for clang 16 or earlier.

Thank you,
Ramin